### PR TITLE
Potential fix for code scanning alert no. 46: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
     "mongoose": "^8.6.3",
     "mongoose-aggregate-paginate-v2": "^1.1.2",
     "multer": "^1.4.5-lts.1",
-    "router": "^1.3.8"
+    "router": "^1.3.8",
+    "express-rate-limit": "^8.0.1"
   }
 }

--- a/server/src/routes/user.routes.js
+++ b/server/src/routes/user.routes.js
@@ -1,3 +1,4 @@
+import RateLimit from "express-rate-limit";
 import { Router } from "express";
 import {
   changeCurrentPassword,
@@ -13,6 +14,13 @@ import { getUserProducts } from "../controllers/product.controller.js";
 import { verifyJWT } from "../middlewares/auth.middleware.js";
 
 const router = Router();
+
+// Rate limiter: maximum of 10 requests per minute for updateRole route
+const updateRoleRateLimiter = RateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // max 10 requests per windowMs
+});
+
 router.route("/register").post(registerUser);
 
 router.route("/get-user-products").get(verifyJWT, getUserProducts);
@@ -29,6 +37,6 @@ router.route("/current-user").get(verifyJWT, getCurrentUser);
 
 router.route("/update-details").patch(verifyJWT, updateAccountDetails);
 
-router.route("/update-role").patch(verifyJWT, updateRole);
+router.route("/update-role").patch(updateRoleRateLimiter, verifyJWT, updateRole);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/DeepakSingh0027/OneMove-WebApp/security/code-scanning/46](https://github.com/DeepakSingh0027/OneMove-WebApp/security/code-scanning/46)

To fix the problem, add rate-limiting middleware to the `updateRole` route to limit the number of requests a user can make within a specific time window. This can be achieved using the `express-rate-limit` package. The middleware should be configured to set a reasonable rate (e.g., 10 requests per minute) to prevent abuse while allowing legitimate usage.

Steps:
1. Install the `express-rate-limit` package if it's not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate limiter specific to the `updateRole` route.
4. Apply the rate limiter middleware to the `updateRole` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
